### PR TITLE
0.5.1 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Manual tests allows you to write your own create/delete/post/observe requests an
 * In terminal run __python3 ./client.py__ This will bring you to python command line prompt
 * In python cmd type a request in the following format: [ request type ] [ content format ] [ uri path ] [ payload(for POST) ] [ observe mode (for OBSERVE) ] [ time out (for OBSERVE) ]. Here are some examples for each of the requests:
 
-  * __POST__: _post json /kv/test/key {"name":Mike,"age":27}_
+  * __POST__: _post json /kv/test/key {"name":"Mike","age":27}_
   * __GET__: _get json /kv/test/key_
   * __DELETE__: _delete json /kv/test/key_
   * __OBSERVE__: _observe json /kv/test/key data 0_

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 This python client connects with the zest datastore.
 
+### Testing the client:
+#### Prerequisites for testing:
+In terminal (inside PythonZestClient folder):
+
+* __./setupTest.sh__ (this will deploy zest database server so client could make requests to it)
+* __docker logs zest -f__ (this will enable server logs so you can see server responses for client requests e.g. in case if some debugging is needed)
+
+#### Automatic tests:
+
+* In terminal run __./setupTest.sh__ (these auto tests will check that create/delete/post requests work properly)
+
+#### Manual testing:
+
+Manual tests allows you to write your own create/delete/post/observe requests and see responses from server for each of them.
+* In terminal run __python3 ./client.py__ This will bring you to python command line prompt
+* In python cmd type a request in the following format: [ request type ] [ content format ] [ uri path ] [ payload(for POST) ] [ observe mode (for OBSERVE) ] [ time out (for OBSERVE) ]. Here are some examples for each of the requests:
+
+  * __POST__: _post json /kv/test/key {"name":Mike,"age":27}_
+  * __GET__: _get json /kv/test/key_
+  * __DELETE__: _delete json /kv/test/key_
+  * __OBSERVE__: _observe json /kv/test/key data 0_
+  
 ### Development of databox was supported by the following funding
 EP/N028260/1, Databox: Privacy-Aware Infrastructure for Managing Personal Data
 

--- a/client.py
+++ b/client.py
@@ -1,0 +1,54 @@
+import pythonzestclient
+import sys, getopt
+
+zestEndpoint="tcp://127.0.0.1:5555"
+zestDealerEndpoint="tcp://127.0.0.1:5556"
+CORE_STORE_KEY="vl6wu0A@XP?}Or/&BR#LSxn>A+}L)p44/W[wXL3<"
+tokenString=b"secrete"
+
+client = pythonzestclient.PyZestClient(CORE_STORE_KEY,zestEndpoint,zestDealerEndpoint)
+
+
+cmd = input("input request > ")
+while cmd != 'exit()':
+    args = cmd.split()
+
+    if args[0] == 'get':
+        try:
+            contentFormat, path = args[1:3]
+            print(f"Sending {args[0]} request...")
+            # request example: get json /kv/test/key
+            print("Response: ", client.get(path, contentFormat,tokenString))
+        except:
+            print("ERROR: wrong number of arguments")
+
+    elif args[0] == 'post':
+        try:
+            contentFormat, path, payLoad = args[1:4]
+            print(f"Sending {args[0]} request...")
+            # request example: post json /kv/test/key "{\"name\":\"tosh\",\"age\":38}"}
+            print("Response: ", client.post(path, payLoad, contentFormat, tokenString))
+        except:
+            print("ERROR: wrong number of arguments")
+
+    elif args[0] == 'delete':
+        try:
+            contentFormat, path = args[1:3]
+            print(f"Sending {args[0]} request...")
+            # request example: delete json /kv/test/key
+            print("Response: ", client.delete(path, contentFormat, tokenString))
+        except:
+            print("ERROR: wrong number of arguments")
+
+    elif args[0] == 'observe':
+        try:
+            contentFormat, path, observeMode, timeOut = args[1:5]
+            print(f"Sending {args[0]} request...")
+            # request example: observe json /kv/test/key data 0
+            print("Response: ", client.observe(path, contentFormat, tokenString, observeMode, int(timeOut)))
+        except:
+            print("ERROR: wrong number of arguments")
+    else:
+        print("ERROR: unsupported request method")
+        
+    cmd = input("input request > ")

--- a/pythonzestclient/__init__.py
+++ b/pythonzestclient/__init__.py
@@ -2,7 +2,4 @@ __author__ = 'pooyadav'
 
 from pythonzestclient.pyZestClient import *
 from pythonzestclient.pyZestUtil import *
-from pythonzestclient.exception.pyZestException import *
-
-
-
+from pythonzestclient.Exception import *

--- a/pythonzestclient/__init__.py
+++ b/pythonzestclient/__init__.py
@@ -2,4 +2,4 @@ __author__ = 'pooyadav'
 
 from pythonzestclient.pyZestClient import *
 from pythonzestclient.pyZestUtil import *
-from pythonzestclient.Exception import *
+from pythonzestclient.exception import *

--- a/pythonzestclient/exception/PyZestException.py
+++ b/pythonzestclient/exception/PyZestException.py
@@ -1,0 +1,12 @@
+__author__ = 'pooyadav'
+
+
+class IllegalFormatException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class PyZestException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+

--- a/pythonzestclient/pyZestClient.py
+++ b/pythonzestclient/pyZestClient.py
@@ -14,7 +14,7 @@ from pythonzestclient import pyZestUtil
 import socket as sc
 
 
-from pythonzestclient.Exception import PyZestException
+from pythonzestclient.exception import PyZestException
 
 
 class PyZestClient:
@@ -26,25 +26,34 @@ class PyZestClient:
         :param certificate_file - Client certificate file used to establish conn with the Server using CURVE zmq api
         """
 
-        self.logger = logger or logging.getLogger(__name__)
-        self.logger.setLevel(logging.NOTSET)
-        self.serverKey = server_key
-        self.endpoint = end_point
+        self.logger = logger or logging.getLogger(__name__) #get the Logger object
+        self.logger.setLevel(logging.INFO) # set which kind of errors should be output (e.g. logging.INFO - starting from INFO severity level)
+        self.serverKey = server_key #key to the ZEST db server, usually string
+        self.endpoint = end_point #zest endpoint
+        #vs451: added dealer_endpoint assignment
+        self.dealer_endpoint = dealer_endpoint
         self.logger.debug("Connecting to the server")
         self.observers = {}
+        #the TRY block describes connection establishment with the server and dealer_endpoint
         try:
+            #connection with server
             ctx = zmq.Context()
-            auth = ThreadAuthenticator(ctx)
+            auth = ThreadAuthenticator(ctx) #runs authentification as a background thread within a specific context
             auth.start()
-            auth.configure_curve(domain='*', location=zmq.auth.CURVE_ALLOW_ANY)
-            self.socket = ctx.socket(zmq.REQ)
+            auth.configure_curve(domain='*', location=zmq.auth.CURVE_ALLOW_ANY) #configure CURVE authentification for a given fomain ('*' - for all domains)
+            self.socket = ctx.socket(zmq.REQ) #initialize request socket
             client_public, client_secret = zmq.curve_keypair()
+            #assigning public and private keys to REQ socket
             self.socket.curve_secretkey = client_secret
             self.socket.curve_publickey = client_public
 
             self.socket.curve_serverkey = bytes(server_key, 'utf8')
             self.socket.connect(end_point)
             self.logger.info('Connection established with ' + end_point)
+
+            #connection with dealer
+            self.socket_d = ctx.socket(zmq.DEALER)
+
 
         except zmq.ZMQError as e:
             self.logger.error("Cannot establish connection" + str(e))
@@ -53,6 +62,7 @@ class PyZestClient:
     def post(self,path, payLoad, contentFormat,tokenString=None):
 
         self.logger.debug("Posting data to the endpoint")
+        #return dictionary struct of header
         header = pyZestUtil.zestHeader()
         header["code"] = 2
         header["token"] = tokenString
@@ -61,16 +71,17 @@ class PyZestClient:
         header["oc"] = 3
 
 
-        # set header options
+        # set header options as an array of dictionaries
         options = []
+        #append Uri-path
         options.append({"number":11,
         "len": len(path),
         "value": path,})
-
+        #append Uri-host
         options.append({"number": 3,
                         "len": len(sc.gethostname()),
                         "value": sc.gethostname(),})
-
+        #append content format
         options.append({"number": 12,
                         "len": 2,
                         "value": pyZestUtil.content_format_to_int(contentFormat),})
@@ -128,9 +139,47 @@ class PyZestClient:
             return parsed_response
         except Exception as e:
             self.logger.error( "Inside GET: Message sending error  " + str(e.args))
+    #vs451: added delete method
+    def delete(self, path, contentFormat, tokenString=None):
+        self.logger.debug("Inside DELETE: deleting data from the endpoint")
+        header = pyZestUtil.zestHeader()
+        header["code"] = 4
+        header["token"] = tokenString
+        header["tkl"] = len(tokenString)
+        header["oc"] = 3
 
 
-    def observe(self, path, contentFormat, tokenString=None, timeOut = 0):
+
+        # set header options
+        options = []
+        options.append({"number":11,
+        "len": len(path),
+        "value": path,})
+
+        options.append({"number": 3,
+                        "len": len(sc.gethostname()),
+                        "value": sc.gethostname(),})
+
+        options.append({"number": 12,
+                        "len": 2,
+                        "value": pyZestUtil.content_format_to_int(contentFormat),})
+        header["options"] = options
+
+        # header marshal into bytes
+        header_into_bytes = pyZestUtil.marshalZestHeader(header)
+
+        try:
+            response = self.send_request_and_await_response(header_into_bytes)
+            try:
+                parsed_response = self.handle_response(response,self.returnPayload)
+            except Exception as e:
+                self.logger.error("Inside DELETE: Error in handling response -" + str(e.args))
+            return parsed_response
+        except Exception as e:
+            self.logger.error( "Inside DELETE: Message sending error  " + str(e.args))
+
+    #vs451: added observeMode parameter ("data" or "audit" values)
+    def observe(self, path, contentFormat, tokenString=None, observeMode = None, timeOut = 0):
         self.logger.debug("Observing data from the endpoint")
         header = pyZestUtil.zestHeader()
         header["code"] = 1
@@ -144,12 +193,14 @@ class PyZestClient:
         options.append({"number": 3,
                         "len": len(sc.gethostname()),
                         "value": sc.gethostname(),})
+        #Q: guess this is observe option("data" or "audit")
         options.append({"number": 6,
-                    "len": 0,
-                    "value":"",})
+                    "len": len(observeMode), #vs451 added observe Mode len assignment
+                    "value":observeMode,}) #vs451 added observe Mode value assignment
         options.append({"number": 12,
                     "len": 2,
                     "value": pyZestUtil.content_format_to_int(contentFormat),})
+        #append Max-Age
         options.append({"number": 14,
                         "len": 4,
                         "value": timeOut,})
@@ -162,9 +213,10 @@ class PyZestClient:
             self.logger.error("Inside Observe: Message sending error - " + str(e.args))
         try:
             parsed_response = self.handle_response(response, self.resolve)
+            return parsed_response
         except Exception as e:
             self.logger.error("Inside Observe: Error in handling response: " + str(e.args[0]))
-        return 1
+        #return 1 vs451: made observe method to return parsed_response instead of 1
 
 
     def resolve(self, header):
@@ -203,11 +255,13 @@ class PyZestClient:
             self.logger.error("Inside Resolve: Error setting dealer Server key - " + str(e.args))
         try:
             dealer.connect(self.dealer_endpoint)
+            print("connected to dealer")
         except Exception as e:
             self.logger.error("Inside Resolve: Error connecting dealer - " + str(e.args))
 
         try:
             message = dealer.recv(0)
+            #print(message)
         except Exception as e:
             self.logger.error("Inside resolve: Didn't get reponse " + str(e.args))
         parsed_response  = self.handle_response(message,self.returnPayload)
@@ -243,9 +297,14 @@ class PyZestClient:
         try:
             if zr["code"] == 65:
                 return zr
+            #vs451: added delete response code
+            elif zr["code"] == 66:
+                return fun(zr)
             elif zr["code"] == 69:
-                pl = fun(zr)
-                return zr["payload"]
+                #commented two following lines as want the method to return payload
+                #pl = fun(zr)
+                #return zr["payload"]
+                return fun(zr)
             elif zr["code"]== 128:
                 # Code 128 corresponds to bad request
                 raise PyZestException(zr, "Bad Request")

--- a/pythonzestclient/pyZestClient.py
+++ b/pythonzestclient/pyZestClient.py
@@ -14,7 +14,7 @@ from pythonzestclient import pyZestUtil
 import socket as sc
 
 
-from pythonzestclient.exception.pyZestException import PyZestException
+from pythonzestclient.Exception import PyZestException
 
 
 class PyZestClient:
@@ -27,7 +27,7 @@ class PyZestClient:
         """
 
         self.logger = logger or logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG)
+        self.logger.setLevel(logging.NOTSET)
         self.serverKey = server_key
         self.endpoint = end_point
         self.logger.debug("Connecting to the server")
@@ -47,7 +47,7 @@ class PyZestClient:
             self.logger.info('Connection established with ' + end_point)
 
         except zmq.ZMQError as e:
-            self.logger.error("Cannot establish connection" + str(e.args))
+            self.logger.error("Cannot establish connection" + str(e))
 
 
     def post(self,path, payLoad, contentFormat,tokenString=None):
@@ -268,6 +268,3 @@ class PyZestClient:
         self.socket.close()
     def stopObserving(self):
         pass
-
-
-

--- a/pythonzestclient/pyZestClient.py
+++ b/pythonzestclient/pyZestClient.py
@@ -82,11 +82,10 @@ class PyZestClient:
         try:
             response = self.send_request_and_await_response(header_into_bytes)
             try:
-                parsed_response = self.handle_response(response, self.returnInput)
+                parsed_response = self.handle_response(response, self.returnPayload)
             except Exception as e:
                 self.logger.error("Inside Post: Error in handling response - " + str(e.args))
-
-                return parsed_response["payload"]
+            return parsed_response["payload"]
         except Exception as e:
             self.logger.error( "Inside Post: Message sending error - " + str(e.args))
 
@@ -203,7 +202,7 @@ class PyZestClient:
         except Exception as e:
             self.logger.error("Inside Resolve: Error setting dealer Server key - " + str(e.args))
         try:
-            dealer.connect(dealer_endpoint)
+            dealer.connect(self.dealer_endpoint)
         except Exception as e:
             self.logger.error("Inside Resolve: Error connecting dealer - " + str(e.args))
 
@@ -245,8 +244,8 @@ class PyZestClient:
             if zr["code"] == 65:
                 return zr
             elif zr["code"] == 69:
-                x = fun(zr)
-                return 0
+                pl = fun(zr)
+                return zr["payload"]
             elif zr["code"]== 128:
                 # Code 128 corresponds to bad request
                 raise PyZestException(zr, "Bad Request")
@@ -262,9 +261,12 @@ class PyZestClient:
 
     def returnPayload(self, x):
         return x["payload"]
+
     def returnInput(self, x):
         return x
+
     def closeSockets(self):
         self.socket.close()
+
     def stopObserving(self):
         pass

--- a/pythonzestclient/pyZestUtil.py
+++ b/pythonzestclient/pyZestUtil.py
@@ -106,7 +106,6 @@ def MarshalZestOptionsHeader(zoh):
     return buff1
 
 def parseZestOptionsHeader(msg, offset):
-    print("Inside Parse Option Header")
     zoh = newZestOptionHeader(0,0,0)
     zoh["number"] = int.from_bytes(bytes(msg[offset:offset+2]),byteorder='big',signed=True)
     zoh["len"] = int.from_bytes(bytes(msg[offset+2:offset+4]),byteorder='big',signed=True)

--- a/pythonzestclient/pyZestUtil.py
+++ b/pythonzestclient/pyZestUtil.py
@@ -25,8 +25,8 @@ def check_content_format(format):
     else:
         raise Exception("KKK")
 
-
-content_format_to_int = lambda format: format_map.get(format, 0)
+#vs451: added format.upper() to correctly map format string to the respective integer value
+content_format_to_int = lambda format: format_map.get(format.upper(), 0)
 
 
 def parse(msg):

--- a/setupTest.sh
+++ b/setupTest.sh
@@ -1,0 +1,6 @@
+
+docker kill zest
+
+ZEST_IMAGE_VERSION="databoxsystems/zestdb-amd64:latest"
+
+docker run -p 5555:5555 -p 5556:5556 -d --name zest --rm ${ZEST_IMAGE_VERSION} /app/zest/server.exe --secret-key-file example-server-key --identity '127.0.0.1' --enable-logging

--- a/setupTest.sh
+++ b/setupTest.sh
@@ -1,6 +1,8 @@
 
 docker kill zest
 
-ZEST_IMAGE_VERSION="databoxsystems/zestdb-amd64:latest"
+ZEST_IMAGE_VERSION="jptmoore/zest:v0.1.1"
 
-docker run -p 5555:5555 -p 5556:5556 -d --name zest --rm ${ZEST_IMAGE_VERSION} /app/zest/server.exe --secret-key-file example-server-key --identity '127.0.0.1' --enable-logging
+
+echo "start the store with the default key"
+docker run -p 5555:5555 -p 5556:5556 -d --name zest -v /tmp/storekey.txt:/storekey.txt --rm ${ZEST_IMAGE_VERSION} /app/zest/server.exe --secret-key-file example-server-key --identity '127.0.0.1' --enable-logging

--- a/zestClientTest.py
+++ b/zestClientTest.py
@@ -1,0 +1,34 @@
+import pythonzestclient
+import unittest
+
+zestEndpoint="tcp://127.0.0.1:5555"
+zestDealerEndpoint="tcp://127.0.0.1:5556"
+CORE_STORE_KEY="vl6wu0A@XP?}Or/&BR#LSxn>A+}L)p44/W[wXL3<"
+tokenString=b"secrete"
+
+class WriteReadTestCase(unittest.TestCase):
+    def setUp(self):
+        self.zc = pythonzestclient.PyZestClient(CORE_STORE_KEY,zestEndpoint,zestDealerEndpoint)
+
+    def tearDown(self):
+        print("Tearing Down")
+
+    def testKVWrite(self):
+        print("testKVWrite")
+        payLoad='{"name":"testuser", "age":37}'
+        path='/kv/test/key1'
+        contentFormat='JSON'
+        response = self.zc.post(path, payLoad, contentFormat,tokenString)
+        self.assertEqual(response,None)
+
+    def testKVRead(self):
+        print("testKVRead")
+        expected='{"name":"testuser", "age":37}'
+        path='/kv/test/key1'
+        contentFormat='JSON'
+        response = self.zc.get(path, contentFormat,tokenString)
+        print("ReadTestCase:: response=" + str(response))
+        self.assertEqual(response,expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zestClientTest.py
+++ b/zestClientTest.py
@@ -10,16 +10,25 @@ class WriteReadTestCase(unittest.TestCase):
     def setUp(self):
         self.zc = pythonzestclient.PyZestClient(CORE_STORE_KEY,zestEndpoint,zestDealerEndpoint)
 
-    def tearDown(self):
-        print("Tearing Down")
+    def testKVRead(self):
+        print("testKVRead")
+        expected='{"name":"testuser1","age":38}'
+        path='/kv/test/key1'
+        contentFormat='JSON'
+
+        response = self.zc.post(path, expected, contentFormat,tokenString)
+        self.assertEqual(response,"")
+
+        response = self.zc.get(path, contentFormat,tokenString)
+        self.assertEqual(response,expected)
 
     def testKVWrite(self):
         print("testKVWrite")
-        payLoad='{"name":"testuser", "age":37}'
+        payLoad='{"name":"testuser2","age":38}'
         path='/kv/test/key1'
         contentFormat='JSON'
         response = self.zc.post(path, payLoad, contentFormat,tokenString)
-        self.assertEqual(response,None)
+        self.assertEqual(response,"")
 
     def testKVRead(self):
         print("testKVRead")

--- a/zestClientTest.py
+++ b/zestClientTest.py
@@ -10,34 +10,51 @@ class WriteReadTestCase(unittest.TestCase):
     def setUp(self):
         self.zc = pythonzestclient.PyZestClient(CORE_STORE_KEY,zestEndpoint,zestDealerEndpoint)
 
-    def testKVRead(self):
-        print("testKVRead")
-        expected='{"name":"testuser1","age":38}'
-        path='/kv/test/key1'
-        contentFormat='JSON'
-
-        response = self.zc.post(path, expected, contentFormat,tokenString)
-        self.assertEqual(response,"")
-
-        response = self.zc.get(path, contentFormat,tokenString)
-        self.assertEqual(response,expected)
-
     def testKVWrite(self):
-        print("testKVWrite")
+        print('----------------------\n|       testKVWrite   |\n ----------------------')
         payLoad='{"name":"testuser2","age":38}'
         path='/kv/test/key1'
         contentFormat='JSON'
+        print("\t*posted: " + payLoad)
         response = self.zc.post(path, payLoad, contentFormat,tokenString)
         self.assertEqual(response,"")
 
     def testKVRead(self):
-        print("testKVRead")
-        expected='{"name":"testuser", "age":37}'
+        print('----------------------\n|       testKVRead    |\n ----------------------')
+        expected='{"name":"testuser3","age":39}'
         path='/kv/test/key1'
         contentFormat='JSON'
+        print("\t*posted: " + expected)
+        response = self.zc.post(path, expected, contentFormat,tokenString)
+        self.assertEqual(response,"")
+
         response = self.zc.get(path, contentFormat,tokenString)
-        print("ReadTestCase:: response=" + str(response))
+        print("\t*read: " + response)
         self.assertEqual(response,expected)
+
+    def testKVDelete(self):
+        print('''-----------------------\n|       testKVDelete  |\n ----------------------''')
+        payLoad='{"name":"testuser5","age":33}'
+        path='/kv/test/key1'
+        contentFormat='JSON'
+
+        response = self.zc.post(path, payLoad, contentFormat,tokenString)
+        self.assertEqual(response,"")
+        print("\t*posted: " + payLoad)
+
+        response = self.zc.get(path, contentFormat,tokenString)
+        print("\t*read: " + response)
+        self.assertEqual(response, payLoad)
+
+        expected = '{}'
+        response = self.zc.delete(path, contentFormat,tokenString)
+        print("\t*deleted: " + payLoad)
+        self.assertEqual(response, "")
+
+        response = self.zc.get(path, contentFormat,tokenString)
+        print("\t*read: " + response)
+        self.assertEqual(response,'{}')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Description of changes:

**pyZestClient.py**

- added dealer_endpoint assignment in PyZestClient class
- added "delete" request
- Observe method: support for observeMode parameter to enable "data" or "audit" observes;
- Observe method now returns parsed_response instead of "1"


**pyZestUtil.py**

- method content_format_to_int: corrected error with mapping content format ('JSON', 'TEXT', 'BINARY') to their int values

**Other**

- added a simple client.py script to test the client outside the databox at runtime. The client runs until you input "exit()" command, command format: method + format + path + payload (if required). Example: _post json /kv/test/key {"name":"Mike","age":28}_ 
